### PR TITLE
timer with summary

### DIFF
--- a/Producer/plugins/PandaProducer.cc
+++ b/Producer/plugins/PandaProducer.cc
@@ -424,21 +424,13 @@ PandaProducer::endJob()
   if (printLevel_ >= 1) {
     std::cout << "[PandaProducer::endJob] Timer summary" << std::endl;
     for (unsigned iF(0); iF != fillers_.size(); ++iF) {
-      std::cout << " " << fillers_[iF]->getName() << "  ";
-      double time(toMS(timers_[iF]));
-      if (time > 10000.)
-        std::cout << std::fixed << std::setprecision(5) << time / nEvents_ / 1000. << " s/evt";
-      else
-        std::cout << time / nEvents_ << " ms/evt";
-      std::cout << std::endl;
+      std::cout << " " << fillers_[iF]->getName() << "  "
+                << std::fixed << std::setprecision(3) << toMS(timers_[iF]) / nEvents_ << " ms/evt"
+                << std::endl;
     }
-    std::cout << " Other CMSSW  ";
-    double time(toMS(timers_.back()));
-    if (time > 10000.)
-      std::cout << std::fixed << std::setprecision(5) << time / nEvents_ / 1000. << " s/evt";
-    else
-      std::cout << time / nEvents_ << " ms/evt";
-    std::cout << std::endl;
+    std::cout << " Other CMSSW  "
+              << std::fixed << std::setprecision(3) << toMS(timers_.back()) / nEvents_ << " ms/evt"
+              << std::endl;
   }
 }
 


### PR DESCRIPTION
Built up on Sid's timer update. With printLevel >= 1, saves the time spent on individual filler modules separately and prints out a summary at the end. Time profile for each event is still turned on only if printLevel >= 3.

Also the previous version was showing the time spent on the last filler module as the CMSSW step time. Fixed that, and now we get somewhat different story. Results for TTGJets 100 events:

[PandaProducer::endJob]
 Timer summary
 ak4GenJets  3 ms
 ak8GenJets  0 ms
 ca15GenJets  0 ms
 chsAK4Jets  20 ms
 chsAK8Jets  4952 ms
 chsCA15Jets  9377 ms
 electrons  73 ms
 genParticles  11 ms
 hlt  0 ms
 metFilters  0 ms
 metNoFix  0 ms
 muons  34 ms
 partons  0 ms
 pfCandidates  276 ms
 pfMet  9 ms
 photons  84 ms
 puppiAK4Jets  5 ms
 puppiAK8Jets  4275 ms
 puppiCA15Jets  7981 ms
 puppiMet  0 ms
 recoil  0 ms
 rho  0 ms
 superClusters  1 ms
 taus  4 ms
 vertices  12 ms
 weights  1 ms
 Other CMSSW  22.37500 s