### PR TITLE
filling LHE info from LHEEvnetProduct with any label

### DIFF
--- a/Producer/interface/FillerBase.h
+++ b/Producer/interface/FillerBase.h
@@ -43,6 +43,8 @@ class FillerBase {
   virtual void fillBeginRun(panda::Run&, edm::Run const&, edm::EventSetup const&) {}
   //! Fill the run tree
   virtual void fillEndRun(panda::Run&, edm::Run const&, edm::EventSetup const&) {}
+  //! Called (indirectly) by CMSSW framework whenever a new product is registered to Event
+  virtual void notifyNewProduct(edm::BranchDescription const&, edm::ConsumesCollector&) {}
 
   std::string const& getName() const { return fillerName_; }
   bool enabled() const { return enabled_; }

--- a/Producer/interface/PartonsFiller.h
+++ b/Producer/interface/PartonsFiller.h
@@ -12,6 +12,7 @@ class PartonsFiller : public FillerBase {
 
   void branchNames(panda::utils::BranchList& eventBranches, panda::utils::BranchList&) const override;
   void fill(panda::Event&, edm::Event const&, edm::EventSetup const&) override;
+  void notifyNewProduct(edm::BranchDescription const&, edm::ConsumesCollector&) override;
 
  protected:
   NamedToken<LHEEventProduct> lheEventToken_;

--- a/Producer/interface/WeightsFiller.h
+++ b/Producer/interface/WeightsFiller.h
@@ -31,6 +31,7 @@ class WeightsFiller : public FillerBase {
 
  protected:
   void getLHEWeights_(LHEEventProduct const&);
+  void bookGenParam_();
 
   NamedToken<GenEventInfoProduct> genInfoToken_;
   NamedToken<LHEEventProduct> lheEventToken_;
@@ -44,7 +45,6 @@ class WeightsFiller : public FillerBase {
 
   double central_{0.};
   double qcdVariations_[7]{};
-  double originalXWGTUP_{0.}; // this is probably always the same as central
   float genParam_[1024]{}; // I don't like that we hard-code the array size here..
 
   // these objects will be deleted automatically when the output file closes

--- a/Producer/interface/WeightsFiller.h
+++ b/Producer/interface/WeightsFiller.h
@@ -9,6 +9,7 @@
 
 #include "FillerBase.h"
 
+#include "FWCore/Framework/interface/GetterOfProducts.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
@@ -19,37 +20,38 @@
 class WeightsFiller : public FillerBase {
  public:
   WeightsFiller(std::string const&, edm::ParameterSet const&, edm::ConsumesCollector&);
-  ~WeightsFiller();
+  ~WeightsFiller() {}
 
   void branchNames(panda::utils::BranchList&, panda::utils::BranchList&) const override;
   void addOutput(TFile&) override;
-  void fill(panda::Event&, edm::Event const&, edm::EventSetup const&) override;
   void fillAll(edm::Event const&, edm::EventSetup const&) override;
+  void fill(panda::Event&, edm::Event const&, edm::EventSetup const&) override;
   void fillEndRun(panda::Run&, edm::Run const&, edm::EventSetup const&) override;
+  void notifyNewProduct(edm::BranchDescription const&, edm::ConsumesCollector&) override;
 
  protected:
-  void getLHEWeights_(LHEEventProduct const&, double [7]);
+  void getLHEWeights_(LHEEventProduct const&);
 
   NamedToken<GenEventInfoProduct> genInfoToken_;
   NamedToken<LHEEventProduct> lheEventToken_;
-  NamedToken<LHERunInfoProduct> lheRunToken_;
+
+  // learn the size of the signal weights vector in the first 100 events
+  static unsigned const learningPhase{100};
   
-  bool saveSignalWeights_{false};
-  int nSignalWeights_{-1};
+  std::vector<TString> wids_{};
+  float genParamBuffer_[learningPhase][1024]{};
+  unsigned bufferCounter_{0};
+
+  double central_{0.};
+  double qcdVariations_[7]{};
+  double originalXWGTUP_{0.}; // this is probably always the same as central
   float genParam_[1024]{}; // I don't like that we hard-code the array size here..
 
   // these objects will be deleted automatically when the output file closes
   TH1D* hSumW_{0};
-  TTree* groupTree_{0};
-  TTree* weightTree_{0};
 
-  TString* gcombine_{0};
-  TString* gtype_{0};
-  TString* wid_{0};
-  TString* wtitle_{0};
-  unsigned gid_{0};
-  
-  TTree* eventTree_{0};
+  // need to hold on to the output file handle
+  TFile* outputFile_{0};
 };
 
 #endif

--- a/Producer/plugins/PandaProducer.cc
+++ b/Producer/plugins/PandaProducer.cc
@@ -128,6 +128,13 @@ PandaProducer::PandaProducer(edm::ParameterSet const& _cfg) :
     // timer for the CMSSW execution outside of this module
     timers_.push_back(SClock::duration::zero());
   }
+
+  // The lambda function inside will be called by CMSSW Framework whenever a new product is registered
+  callWhenNewProductsRegistered([this](edm::BranchDescription const& branchDescription) {
+      auto&& coll(this->consumesCollector());
+      for (auto* filler : this->fillers_)
+        filler->notifyNewProduct(branchDescription, coll);
+    });
 }
 
 PandaProducer::~PandaProducer()

--- a/Producer/python/panda_cfi.py
+++ b/Producer/python/panda_cfi.py
@@ -12,8 +12,6 @@ panda = cms.EDAnalyzer('PandaProducer',
         common = cms.untracked.PSet(
             triggerObjects = cms.untracked.string('selectedPatTrigger'),
             genEventInfo = cms.untracked.string('generator'),
-            lheEvent = cms.untracked.string('externalLHEProducer'),
-            lheRun = cms.untracked.string('externalLHEProducer'),
             finalStateParticles = cms.untracked.string('packedGenParticles'),
             genParticles = cms.untracked.string('prunedGenParticles'),
             pfCandidates = cms.untracked.string('packedPFCandidates'),
@@ -321,8 +319,7 @@ panda = cms.EDAnalyzer('PandaProducer',
         ),
         weights = cms.untracked.PSet(
             enabled = cms.untracked.bool(True),
-            filler = cms.untracked.string('Weights'),
-            signalWeights = cms.untracked.bool(True)
+            filler = cms.untracked.string('Weights')
         ),
         recoil = cms.untracked.PSet(
             enabled = cms.untracked.bool(True),

--- a/Producer/src/PartonsFiller.cc
+++ b/Producer/src/PartonsFiller.cc
@@ -3,7 +3,9 @@
 PartonsFiller::PartonsFiller(std::string const& _name, edm::ParameterSet const& _cfg, edm::ConsumesCollector& _coll) :
   FillerBase(_name, _cfg)
 {
-  getToken_(lheEventToken_, _cfg, _coll, "common", "lheEvent");
+  // Some samples have non-standard LHEEventProduct names
+  // Using notifyNewProduct() to dynamically find the tag
+  lheEventToken_.first = "lheEvent";
 }
 
 void
@@ -34,6 +36,15 @@ PartonsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::Ev
     outParton.setXYZE(pup[0], pup[1], pup[2], pup[3]);
 
     outParton.pdgid = hepeup.IDUP[iP];
+  }
+}
+
+void
+PartonsFiller::notifyNewProduct(edm::BranchDescription const& _bdesc, edm::ConsumesCollector& _coll)
+{
+  if (_bdesc.unwrappedTypeID() == edm::TypeID(typeid(LHEEventProduct))) {
+    edm::InputTag tag(_bdesc.moduleLabel(), _bdesc.productInstanceName(), _bdesc.processName());
+    lheEventToken_.second = _coll.consumes<LHEEventProduct>(tag);
   }
 }
 

--- a/Producer/src/WeightsFiller.cc
+++ b/Producer/src/WeightsFiller.cc
@@ -8,23 +8,17 @@
 #include "TXMLNode.h"
 #include "TXMLAttr.h"
 
+auto GetAll([](edm::BranchDescription const&)->bool { return true; });
+
 WeightsFiller::WeightsFiller(std::string const& _name, edm::ParameterSet const& _cfg, edm::ConsumesCollector& _coll) :
   FillerBase(_name, _cfg)
 {
   if (!isRealData_) {
     getToken_(genInfoToken_, _cfg, _coll, "common", "genEventInfo");
-    getToken_(lheEventToken_, _cfg, _coll, "common", "lheEvent");
-    getTokenRun_(lheRunToken_, _cfg, _coll, "common", "lheRun");
-    saveSignalWeights_ = getParameter_<bool>(_cfg, "signalWeights");
+    // Some samples have non-standard LHEEventProduct names
+    // Using notifyNewProduct() to dynamically find the tag
+    lheEventToken_.first = "lheEvent";
   }
-}
-
-WeightsFiller::~WeightsFiller()
-{
-  delete gcombine_;
-  delete gtype_;
-  delete wid_;
-  delete wtitle_;
 }
 
 void
@@ -64,50 +58,8 @@ WeightsFiller::addOutput(TFile& _outputFile)
     for (unsigned iL(0); iL != sizeof(labels) / sizeof(char const*); ++iL)
       hSumW_->GetXaxis()->SetBinLabel(iL + 2, labels[iL]);
 
-    if (saveSignalWeights_) {
-      weightTree_ = new TTree("weights", "weights");
-      wid_ = new TString;
-      weightTree_->Branch("id", "TString", &wid_); // currently only have the ability to save ID
-
-      // we need a handle to the event tree to book the genParams branch if needed
-      eventTree_ = static_cast<TTree*>(_outputFile.Get("events"));
-
-      if (!eventTree_) // something is very wrong
-        throw std::runtime_error("Event tree is missing from the output");
-    }
+    outputFile_ = &_outputFile;
   }
-}
-
-void
-WeightsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::EventSetup const&)
-{
-  if (isRealData_) {
-    _outEvent.weight = 1.;
-    return;
-  }
-
-  auto& genInfo(getProduct_(_inEvent, genInfoToken_));
-  _outEvent.weight = genInfo.weight();
-
-  auto* lheEvent(getProductSafe_(_inEvent, lheEventToken_));
-  if (!lheEvent)
-    return;
-
-  double weights[7]{};
-    
-  getLHEWeights_(*lheEvent, weights);
-
-  _outEvent.genReweight.r1f2DW = weights[0] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.r1f5DW = weights[1] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.r2f1DW = weights[2] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.r2f2DW = weights[3] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.r5f1DW = weights[4] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.r5f5DW = weights[5] / lheEvent->originalXWGTUP() - 1.;
-  _outEvent.genReweight.pdfDW = weights[6] / lheEvent->originalXWGTUP() - 1.;
-
-  // genParam branch is not filled from the outEvent object, but we copy the value here for consistence
-  // (some other filler module may decide to use the values!)
-  std::copy(genParam_, genParam_ + nSignalWeights_, _outEvent.genReweight.genParam);
 }
 
 void
@@ -119,230 +71,194 @@ WeightsFiller::fillAll(edm::Event const& _inEvent, edm::EventSetup const&)
   }
 
   auto& genInfo(getProduct_(_inEvent, genInfoToken_));
-  hSumW_->Fill(0.5, genInfo.weight());
+  central_ = genInfo.weight();
 
-  auto* lheEvent(getProductSafe_(_inEvent, lheEventToken_));
-  if (!lheEvent)
+  hSumW_->Fill(0.5, central_);
+
+  if (lheEventToken_.second.isUninitialized())
     return;
 
-  double weights[7]{};
-
-  getLHEWeights_(*lheEvent, weights);
+  auto& lheEvent(getProduct_(_inEvent, lheEventToken_));
+  getLHEWeights_(lheEvent);
 
   // PDF variation will always be greater than nominal by construction
   for (unsigned iW(0); iW != 7; ++iW)
-    hSumW_->Fill(iW + 1.5, weights[iW]);
+    hSumW_->Fill(iW + 1.5, qcdVariations_[iW]);
 
-  for (int iS(0); iS != nSignalWeights_; ++iS)
-    hSumW_->Fill(iS + 9.5, genParam_[iS]);
+  for (unsigned iS(0); iS != wids_.size(); ++iS) {
+    if (genParam_[iS] >= 0.)
+      hSumW_->Fill(iS + 9.5, genParam_[iS]);
+  }
 }
 
 void
-WeightsFiller::fillEndRun(panda::Run& _outRun, edm::Run const& _inRun, edm::EventSetup const&)
+WeightsFiller::fill(panda::Event& _outEvent, edm::Event const&, edm::EventSetup const&)
 {
-  // Set weight names
-  // Update this function too if changing the set of weights to save
+  // fillAll is always called before fill
 
-  // LHERunInfoProduct (and GenRunInfoProduct FWIW) have mergeProduct method which forbids them
-  // from being fetched in beginRun
-
-  return; // something is wrong with the LHE header in signal files. fill the tree a different way
-
-  if (isRealData_ || !saveSignalWeights_)
-    return;
-
-  auto* lheRun(getProductSafe_(_inRun, lheRunToken_));
-  if (!lheRun) {
+  if (isRealData_) {
+    _outEvent.weight = 1.;
     return;
   }
 
-  std::map<TString, unsigned> weightGroups; // use TStrings to cover non-int IDs
-  std::map<TString, TString> weightTitles;
+  _outEvent.weight = central_;
 
-  // Parse the LHE run header and find the initrwgt block
-  for (auto&& hItr(lheRun->headers_begin()); hItr != lheRun->headers_end(); ++hItr) {
-    auto& lheHdr(*hItr);
+  _outEvent.genReweight.r1f2DW = qcdVariations_[0] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.r1f5DW = qcdVariations_[1] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.r2f1DW = qcdVariations_[2] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.r2f2DW = qcdVariations_[3] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.r5f1DW = qcdVariations_[4] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.r5f5DW = qcdVariations_[5] / originalXWGTUP_ - 1.;
+  _outEvent.genReweight.pdfDW = qcdVariations_[6] / originalXWGTUP_ - 1.;
 
-    if (lheHdr.tag() != "initrwgt")
-      continue;
+  // genParam branch is not filled from the outEvent object, but we copy the value here for consistence
+  // (some other filler module may decide to use the values!)
+  std::copy(genParam_, genParam_ + wids_.size(), _outEvent.genReweight.genParam);
+}
 
-    // xml document needs a root node
-    TString buffer("<initrwgt>");
+void
+WeightsFiller::fillEndRun(panda::Run&, edm::Run const&, edm::EventSetup const&)
+{
+  if (!isRealData_ && bufferCounter_ < learningPhase) {
+    // Run boundary before getting out of learning phase
+    // It could be a genuine run boundary, but there is no way to tell -> we need to exit learning phase now
 
-    // append lines stripping whitespaces and newlines
-    for (auto&& line : lheHdr.lines()) {
-      TString text(line);
-      text = text.Strip(TString::kBoth, ' ');
-      text = text.Strip(TString::kBoth, '\n');
-      buffer += text;
-    }
+    if (wids_.size() != 0) {
+      TDirectory::TContext context(outputFile_);
 
-    // clean up the buffer - at least remove trailing open bracket (yes that happens sometimes)
-    int len(buffer.Length());
-    for (; len != 0; --len) {
-      if (buffer[len - 1] == '>')
-        break;
-    }
-    buffer = buffer(0, len);
+      auto* weightTree(new TTree("weights", "weights"));
+      auto* wid(new TString);
+      weightTree->Branch("id", "TString", &wid); // currently only have the ability to save ID
 
-    buffer += "</initrwgt>";
-
-
-    TDOMParser parser;
-    parser.SetValidate(false); // we don't define XML namespace etc.
-    parser.ParseBuffer(buffer.Data(), buffer.Length());
-    auto& document(*parser.GetXMLDocument());
-    auto& rootnode(*document.GetRootNode());
-
-    unsigned iG(-1);
-
-    // traverse through the XML document and collect all reweight factor names
-    auto* wgNode(rootnode.GetChildren());
-    do {
-      // ignore non-weightgroup nodes
-      if (std::strcmp(wgNode->GetNodeName(), "weightgroup") != 0)
-        continue;
-
-      ++iG;
-
-      // assume the first block is for scale variation
-      if (iG == 0)
-        continue;
-
-      // loop over weightgroup nodes
-
-      auto* weightNode(wgNode->GetChildren());
-      do {
-        // loop over weight definition nodes
-
-        if (std::strcmp(weightNode->GetNodeName(), "weight") != 0)
-          continue;
-
-        TList* attr(weightNode->GetAttributes());
-        if (!attr)
-          continue;
-
-        auto* wid(static_cast<TXMLAttr*>(attr->FindObject("id")));
-        if (!wid)
-          continue;
-
-        TString id(wid->GetValue());
-
-        weightGroups[id] = iG - 1; // first block is skipped
-
-        // weight definition is a content of the child (text) node
-        auto* contentNode = weightNode->GetChildren();
-        if (!contentNode || contentNode->GetNodeType() != TXMLNode::kXMLTextNode)
-          continue;
-
-        TString content(contentNode->GetContent());
-        content.Strip(TString::kBoth);
-
-        weightTitles[id] = content;
+      for (TString& w : wids_) {
+        *wid = w;
+        weightTree->Fill();
       }
-      while ((weightNode = weightNode->GetNextNode()));
 
-      // weightgroup attributes
-      TList& attributes(*wgNode->GetAttributes());
-          
-      auto* combine(static_cast<TXMLAttr*>(attributes.FindObject("combine")));
-      if (combine)
-        *gcombine_ = combine->GetValue();
-      else
-        *gcombine_ = "";
+      auto* eventTree(static_cast<TTree*>(outputFile_->Get("events")));
+      auto* branch(eventTree->Branch("genReweight.genParam", genParam_, TString::Format("genParam[%d]/F", int(wids_.size()))));
 
-      auto* type(static_cast<TXMLAttr*>(attributes.FindObject("type")));
-      if (type)
-        *gtype_ = type->GetValue();
-      else
-        *gtype_ = "";
-
-      groupTree_->Fill();
+      for (unsigned iE(0); iE != bufferCounter_; ++iE) {
+        std::copy(genParamBuffer_[iE], genParamBuffer_[iE] + wids_.size(), genParam_);
+        branch->Fill();
+      }
     }
-    while ((wgNode = wgNode->GetNextNode()));
 
-    // we don't need to look at any other LHE headers
-    // break;
-  }
-
-  for (auto& idtitle : weightTitles) {
-    *wid_ = idtitle.first;
-    *wtitle_ = idtitle.second;
-    gid_ = weightGroups.at(*wid_);
-    if (TString::Itoa(wid_->Atoi(),10)==*wid_) {
-      weightTree_->Fill();
-    }
+    bufferCounter_ = unsigned(-1);
   }
 }
 
 void
-WeightsFiller::getLHEWeights_(LHEEventProduct const& _lheEvent, double _weights[7])
+WeightsFiller::notifyNewProduct(edm::BranchDescription const& _bdesc, edm::ConsumesCollector& _coll)
 {
-  // Update this function if changing the set of weights to be save
+  // assumption: there should be at most one LHEEventProduct in an event
+  if (_bdesc.unwrappedTypeID() == edm::TypeID(typeid(LHEEventProduct))) {
+    edm::InputTag tag(_bdesc.moduleLabel(), _bdesc.productInstanceName(), _bdesc.processName());
+    lheEventToken_.second = _coll.consumes<LHEEventProduct>(tag);
+  }
+}
+
+void
+WeightsFiller::getLHEWeights_(LHEEventProduct const& _lheEvent)
+{
+  // Update this function if changing the set of weights to save
+
+  originalXWGTUP_ = _lheEvent.originalXWGTUP();
 
   double sumd2(0.);
-  unsigned genParamCounter(0);
-
-  bool firstEvent(nSignalWeights_ < 0);
+  unsigned iS(0);
+  std::fill_n(genParam_, sizeof(genParam_) / sizeof(float), -1.);
 
   for (auto& wgt : _lheEvent.weights()) {
     unsigned id(0);
     try {
-      id =std::stoi(wgt.id);
+      id = std::stoi(wgt.id);
     }
     catch (std::invalid_argument& ex) {
-      if (saveSignalWeights_) {
-        genParam_[genParamCounter++] = wgt.wgt / _lheEvent.originalXWGTUP(); 
+      // assumption: this is signal reweights
 
-        if (firstEvent) {
-          *wid_ = wgt.id.c_str();
-          weightTree_->Fill();
+      if (iS >= wids_.size()) {
+        if (bufferCounter_ < learningPhase) {
+          // assumption: weights always come in the same order, but the list can be truncated
+          wids_.emplace_back(wgt.id);
 
           unsigned nbinsx(hSumW_->GetNbinsX() + 1);
           hSumW_->SetBins(nbinsx, 0., nbinsx);
-          hSumW_->GetXaxis()->SetBinLabel(nbinsx, *wid_);
+          hSumW_->GetXaxis()->SetBinLabel(nbinsx, wgt.id.c_str());
+        }
+        else {
+          std::cerr << "Found more signal weights after the learning phase - cannot handle it." << std::endl;
+          continue;
         }
       }
+
+      genParam_[iS++] = wgt.wgt / originalXWGTUP_; 
+
       continue;
     }
 
     if ((id >= 1 && id <= 9) || (id >= 1001 && id <= 1009)) {
       switch (id % 1000) {
       case 2:
-        _weights[0] = wgt.wgt;
+        qcdVariations_[0] = wgt.wgt;
         break;
       case 3:
-        _weights[1] = wgt.wgt;
+        qcdVariations_[1] = wgt.wgt;
         break;
       case 4:
-        _weights[2] = wgt.wgt;
+        qcdVariations_[2] = wgt.wgt;
         break;
       case 5:
-        _weights[3] = wgt.wgt;
+        qcdVariations_[3] = wgt.wgt;
         break;
       case 7:
-        _weights[4] = wgt.wgt;
+        qcdVariations_[4] = wgt.wgt;
         break;
       case 9:
-        _weights[5] = wgt.wgt;
+        qcdVariations_[5] = wgt.wgt;
         break;
       default:
         break;
       }
     }
     else if ((id >= 11 && id <= 110) || (id >= 2001 && id < 2100)) {
-      double d(wgt.wgt - _lheEvent.originalXWGTUP());
+      double d(wgt.wgt - originalXWGTUP_);
       sumd2 += d * d;
     }
   }
 
-  _weights[6] = std::sqrt(sumd2 / 99.) + _lheEvent.originalXWGTUP();
+  qcdVariations_[6] = std::sqrt(sumd2 / 99.) + _lheEvent.originalXWGTUP();
 
-  if (firstEvent) {
-    nSignalWeights_ = genParamCounter;
+  if (bufferCounter_ < learningPhase) {
+    // save the weights to the buffer
+    std::copy(genParam_, genParam_ + iS, genParamBuffer_[bufferCounter_]);
+    ++bufferCounter_;
+  }
+  else if (bufferCounter_ == learningPhase) {
+    // By now we should know how large the signal weights vector is
 
-    if (nSignalWeights_ > 0)
-      eventTree_->Branch("genReweight.genParam", genParam_, TString::Format("genParam[%d]/F", nSignalWeights_));
+    if (wids_.size() != 0) {
+      TDirectory::TContext context(outputFile_);
+
+      auto* weightTree(new TTree("weights", "weights"));
+      auto* wid(new TString);
+      weightTree->Branch("id", "TString", &wid); // currently only have the ability to save ID
+
+      for (TString& w : wids_) {
+        *wid = w;
+        weightTree->Fill();
+      }
+
+      auto* eventTree(static_cast<TTree*>(outputFile_->Get("events")));
+      auto* branch(eventTree->Branch("genReweight.genParam", genParam_, TString::Format("genParam[%d]/F", int(wids_.size()))));
+
+      for (unsigned iE(0); iE != learningPhase; ++iE) {
+        std::copy(genParamBuffer_[iE], genParamBuffer_[iE] + wids_.size(), genParam_);
+        branch->Fill();
+      }
+    }
+
+    bufferCounter_ = unsigned(-1);
   }
 }
 


### PR DESCRIPTION
Some surgery on WeightsFiller and PartonsFiller.

- To be able to automatically pick up LHEEventProduct with non-standard labels, used an implementation of dynamic branch subscription in http://cmslxr.fnal.gov/source/FWCore/Framework/interface/WillGetIfMatch.h to make the module fully label-independent.
- Weights in some events are broken (seen in powheg for example), leading to truncated weight lists. WeightsFiller will now buffer signal weights for 100 events (or until the end of run, if that comes earlier) before booking the genParams branch.
- Unfilled slots of the genParams array are now set to -1.