### PR TITLE
turning off substructure computation for chsCA15

### DIFF
--- a/Producer/plugins/PandaProducer.cc
+++ b/Producer/plugins/PandaProducer.cc
@@ -422,14 +422,27 @@ PandaProducer::endJob()
   delete outputFile_;
 
   if (printLevel_ >= 1) {
+    double total(0.);
+
     std::cout << "[PandaProducer::endJob] Timer summary" << std::endl;
     for (unsigned iF(0); iF != fillers_.size(); ++iF) {
+      double msPerEvt(toMS(timers_[iF]) / nEvents_);
       std::cout << " " << fillers_[iF]->getName() << "  "
-                << std::fixed << std::setprecision(3) << toMS(timers_[iF]) / nEvents_ << " ms/evt"
+                << std::fixed << std::setprecision(3) << msPerEvt << " ms/evt"
                 << std::endl;
+
+      total += msPerEvt;
     }
-    std::cout << " Other CMSSW  "
-              << std::fixed << std::setprecision(3) << toMS(timers_.back()) / nEvents_ << " ms/evt"
+    if (nEvents_ > 1) {
+      double msPerEvt(toMS(timers_.back()) / (nEvents_ - 1));
+      std::cout << " Other CMSSW  "
+                << std::fixed << std::setprecision(3) << msPerEvt << " ms/evt"
+                << std::endl;
+
+      total += msPerEvt;
+    }
+    std::cout << std::endl << " Total  "
+              << std::fixed << std::setprecision(3) << total << " ms/evt"
               << std::endl;
   }
 }

--- a/Producer/python/panda_cfi.py
+++ b/Producer/python/panda_cfi.py
@@ -111,10 +111,10 @@ panda = cms.EDAnalyzer('PandaProducer',
             subjetBtag = cms.untracked.string('pfCombinedInclusiveSecondaryVertexV2BJetTags'),
             subjetQGL = cms.untracked.string('subQGTagCA15PFchs:qgLikelihood'),
             doubleBTagWeights = cms.untracked.FileInPath('PandaProd/Utilities/data/BoostedSVDoubleCA15_withSubjet_v4.weights.xml'),
-            computeSubstructure = cms.untracked.string('recoil'),
+            computeSubstructure = cms.untracked.string('never'),
             recoil = cms.untracked.string('MonoXFilter:categories'),
             fillConstituents = cms.untracked.bool(True),
-            minPt = cms.untracked.double(100.),
+            minPt = cms.untracked.double(180.),
             maxEta = cms.untracked.double(4.7)
         ),
         puppiCA15Jets = cms.untracked.PSet(
@@ -137,7 +137,7 @@ panda = cms.EDAnalyzer('PandaProducer',
             computeSubstructure = cms.untracked.string('recoil'),
             recoil = cms.untracked.string('MonoXFilter:categories'),
             fillConstituents = cms.untracked.bool(True),
-            minPt = cms.untracked.double(100.),
+            minPt = cms.untracked.double(180.),
             maxEta = cms.untracked.double(4.7)
         ),
         electrons = cms.untracked.PSet(


### PR DESCRIPTION
PandaPhysics/PandaTree#11
Setting CA15 jet minPt to 180 GeV and turning off substructure computation for chsCA15.

Also added a little tweak to time profiler.