### PR TITLE
protection against cyclic graphs

### DIFF
--- a/Producer/src/GenParticlesFiller.cc
+++ b/Producer/src/GenParticlesFiller.cc
@@ -43,6 +43,17 @@ struct PNodeWithPtr : public PNode {
         // this node is already constructed
 
         PNode* dnode(nItr->second);
+
+        // protect against cyclic graphs - is dnode my ancestor?
+        PNode* p(this);
+        while (p) {
+          if (p == dnode)
+            break;
+          p = p->mother;
+        }
+        if (p) // one of my ancestors is dnode; don't add this node as my daughter
+          continue;
+
         PNode* dmother(dnode->mother);
 
         if (dmother) {


### PR DESCRIPTION
Sherpa samples had cyclic decay chains. With this update, we cut the cycle by checking if a daughter of a particle is one of its ancestors, and ignoring this daughter if it is.