### PR TITLE
using reserve to avoid invalidated pointers in objectMap

### DIFF
--- a/Producer/src/GenParticlesFiller.cc
+++ b/Producer/src/GenParticlesFiller.cc
@@ -220,6 +220,8 @@ GenParticlesFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, ed
   }
 
   auto& outParticles(_outEvent.genParticles);
+  outParticles.reserve(inParticles.size() + inFinalStates.size());
+  
   auto& objectMap(objectMap_->get<reco::Candidate, panda::GenParticle>());
 
   for (auto* rootNode : rootNodes) {

--- a/Producer/src/SuperClustersFiller.cc
+++ b/Producer/src/SuperClustersFiller.cc
@@ -28,6 +28,7 @@ SuperClustersFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, e
   noZS::EcalClusterLazyTools lazyTools(_inEvent, _setup, ebHitsToken_.second, eeHitsToken_.second);
 
   auto& outSuperClusters(_outEvent.superClusters);
+  outSuperClusters.reserve(inSuperClusters.size());
 
   auto& objectMap(objectMap_->get<reco::SuperCluster, panda::SuperCluster>());
 

--- a/Producer/src/VerticesFiller.cc
+++ b/Producer/src/VerticesFiller.cc
@@ -47,6 +47,7 @@ VerticesFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::E
   auto& inCandidates(getProduct_(_inEvent, candidatesToken_));
 
   auto& outVertices(_outEvent.vertices);
+  outVertices.reserve(inVertices.size());
 
   auto& objMap(objectMap_->get<reco::Vertex, panda::RecoVertex>());
 


### PR DESCRIPTION
This is an issue that may be causing some seg faults in some of the ongoing production jobs.
In GenParticles, SuperClusters, and VerticesFiller, we fill the objectMap with pointers of output objects as we fill the collection. If collection resize happens in the middle, these pointers become invalid.

The solution is to use the new Collection::reserve() to ensure the allocated collection size is enough at the beginning of the event.