### PR TITLE
bug fix genWeights

### DIFF
--- a/Producer/interface/WeightsFiller.h
+++ b/Producer/interface/WeightsFiller.h
@@ -40,12 +40,12 @@ class WeightsFiller : public FillerBase {
   static unsigned const learningPhase{100};
   
   std::vector<TString> wids_{};
-  float genParamBuffer_[learningPhase][1024]{};
+  float genParamBuffer_[learningPhase][panda::GenReweight::NMAX]{};
   unsigned bufferCounter_{0};
 
   double central_{0.};
   double normQCDVariations_[7]{}; // QCD variations (muR, muF, and PDF) normalized by originalXWGTUP
-  float genParam_[1024]{}; // I don't like that we hard-code the array size here..
+  float genParam_[panda::GenReweight::NMAX]{}; // I don't like that we hard-code the array size here..
 
   // these objects will be deleted automatically when the output file closes
   TH1D* hSumW_{0};

--- a/Producer/src/WeightsFiller.cc
+++ b/Producer/src/WeightsFiller.cc
@@ -131,7 +131,7 @@ WeightsFiller::fillEndRun(panda::Run&, edm::Run const&, edm::EventSetup const&)
     // It could be a genuine run boundary, but there is no way to tell -> we need to exit learning phase now
     bookGenParam_();
 
-    bufferCounter_ = learningPhase;
+    bufferCounter_ = 0xffffffff;
   }
 }
 
@@ -233,6 +233,7 @@ WeightsFiller::getLHEWeights_(LHEEventProduct const& _lheEvent)
   else if (bufferCounter_ == learningPhase) {
     // By now we should know how large the signal weights vector is
     bookGenParam_();
+    bufferCounter_ = 0xffffffff;
   }
 }
 


### PR DESCRIPTION
Fix for PandaPhysics/PandaTree#55. `bufferCounter_` variable was left at the `learningPhase`  value, so the Branch function was called for every event after the learning phase. Fixed by setting `bufferCounter_` to 0xffffffff.