### PR TITLE
Compiling and running in CMSSW_9_2_3

### DIFF
--- a/Auxiliary/plugins/WorstIsolationProducer.cc
+++ b/Auxiliary/plugins/WorstIsolationProducer.cc
@@ -117,11 +117,11 @@ WorstIsolationProducer::produce(edm::Event& _event, edm::EventSetup const&)
 
   // Write function
   auto writeProduct([&_event, &photonsHandle, &worstIsolations] {
-      std::auto_ptr<FloatMap> valueMap(new FloatMap());
+      auto valueMap = std::make_unique<FloatMap>();
       FloatMap::Filler filler(*valueMap);
       filler.insert(photonsHandle, worstIsolations.begin(), worstIsolations.end());
       filler.fill();
-      _event.put(valueMap);
+      _event.put(std::move(valueMap));
     });
 
   // Inputs

--- a/Filters/plugins/MonoXFilter.cc
+++ b/Filters/plugins/MonoXFilter.cc
@@ -211,11 +211,11 @@ MonoXFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
     }
   }
 
-  std::auto_ptr<int> categoriesP(new int(categories));
-  std::auto_ptr<double> maxP(new double(maxRecoil));
+  auto categoriesP = std::make_unique<int>(categories);
+  auto maxP = std::make_unique<double>(maxRecoil);
 
-  iEvent.put(categoriesP, "categories");
-  iEvent.put(maxP, "max");
+  iEvent.put(std::move(categoriesP), "categories");
+  iEvent.put(std::move(maxP), "max");
 
   // PInfo("PandaProd::MonoXFilter::analyze",
   //     TString::Format("Rejecting event %llu",iEvent.id().event()));

--- a/Producer/cfg/data.py
+++ b/Producer/cfg/data.py
@@ -1,6 +1,6 @@
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-options =VarParsing('analysis')
+options = VarParsing('analysis')
 options.register('config', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Single-switch config. Values: 03Feb2017, 23Sep2016, Spring16, Summer16')
 options.register('globaltag', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Global tag')
 options.register('connect', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Globaltag connect')
@@ -14,12 +14,17 @@ options._tagOrder.remove('numEvent%d')
 
 options.parseArguments()
 
-options.config = '03Feb2017'
+options.config = 'Prompt17'
 
 jetRecorrection = True
 muFix = True
 egFix = False
 egmSmearingType = 'Moriond2017_JEC'
+egRegression = True
+
+# Global tags
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Global_Tags_for_2017_data_taking
+# https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Global_Tags_for_PdmVMCcampaignPh
 
 if options.config == '03Feb2017':
     jetRecorrection = False
@@ -30,6 +35,12 @@ if options.config == '03Feb2017':
 elif options.config == '23Sep2016':
     options.isData = True
     options.globaltag = '80X_dataRun2_2016SeptRepro_v7'
+elif options.config == 'Prompt17':
+    options.isData = True
+    options.globaltag = '92X_dataRun2_Prompt_v4'
+    egRegression = False
+    jetRecorrection = False
+    muFix = False
 elif options.config == 'Spring16':
     options.isData = False
     options.globaltag = '80X_mcRun2_asymptotic_2016_v3'
@@ -104,43 +115,66 @@ process.RandomNumberGeneratorService.smearedPhotons = cms.PSet(
 ## RECO SEQUENCE AND SKIMS ##
 #############################
 
+
+egmCorrectionSequence = cms.Sequence()
+
+if egRegression:
+
+    ### EGAMMA CORRECTIONS
+    # https://twiki.cern.ch/twiki/bin/view/CMS/EGMRegression
+    # https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer
+
+    from EgammaAnalysis.ElectronTools.regressionApplication_cff import slimmedElectrons as regressionElectrons
+    from EgammaAnalysis.ElectronTools.regressionApplication_cff import slimmedPhotons as regressionPhotons
+    from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
+    regressionWeights(process)
+    process.regressionElectrons = regressionElectrons
+    process.regressionPhotons = regressionPhotons
+
+    process.selectedElectrons = cms.EDFilter('PATElectronSelector',
+        src = cms.InputTag('regressionElectrons'),
+        cut = cms.string('pt > 5 && abs(eta) < 2.5')
+    )
+
+    ## Set names of EG objects
+    electronsName = 'selectedElectrons'
+    photonsName = 'regressionPhotons'
+
+    egmCorrectionSequence += \
+        process.regressionElectrons + \
+        process.regressionPhotons + \
+        process.selectedElectrons
+
+
+else:
+    
+    electronsName = 'slimmedElectrons'
+    photonsName = 'slimmedPhotons'
+
+
 import PandaProd.Producer.utils.egmidconf as egmidconf
-
-### EGAMMA CORRECTIONS
-
-from EgammaAnalysis.ElectronTools.regressionApplication_cff import slimmedElectrons as regressionElectrons
-from EgammaAnalysis.ElectronTools.regressionApplication_cff import slimmedPhotons as regressionPhotons
-from EgammaAnalysis.ElectronTools.regressionWeights_cfi import regressionWeights
-regressionWeights(process)
-process.regressionElectrons = regressionElectrons
-process.regressionPhotons = regressionPhotons
-
-process.selectedElectrons = cms.EDFilter('PATElectronSelector',
-    src = cms.InputTag('regressionElectrons'),
-    cut = cms.string('pt > 5 && abs(eta) < 2.5')
-)
 
 from PandaProd.Producer.utils.calibratedEgamma_cfi import calibratedPatElectrons, calibratedPatPhotons
 process.smearedElectrons = calibratedPatElectrons.clone(
-    electrons = 'selectedElectrons',
+    electrons = electronsName,
     isMC = (not options.isData),
     correctionFile = egmidconf.electronSmearingData[egmSmearingType]
 )
 process.smearedPhotons = calibratedPatPhotons.clone(
-    photons = 'regressionPhotons',
+    photons = photonsName,
     isMC = (not options.isData),
     correctionFile = egmidconf.photonSmearingData[egmSmearingType]
 )   
 
-egmCorrectionSequence = cms.Sequence(
-     process.regressionElectrons +
-     process.regressionPhotons +
-     process.selectedElectrons +
-     process.smearedElectrons +
-     process.smearedPhotons
-)
+egmCorrectionSequence += \
+    process.smearedElectrons + \
+    process.smearedPhotons
+
 
 ### EXTRA MET FILTERS
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2
+# https://github.com/cms-sw/cmssw/blob/CMSSW_8_0_X/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+
 process.load('RecoMET.METFilters.BadPFMuonFilter_cfi')
 process.BadPFMuonFilter.muons = cms.InputTag("slimmedMuons")
 process.BadPFMuonFilter.PFCandidates = cms.InputTag("packedPFCandidates")
@@ -152,14 +186,17 @@ process.BadChargedCandidateFilter.PFCandidates = cms.InputTag("packedPFCandidate
 process.BadChargedCandidateFilter.taggingMode = cms.bool(True)
 
 metFilterSequence = cms.Sequence(
-        process.BadPFMuonFilter + 
-        process.BadChargedCandidateFilter
+    process.BadPFMuonFilter + 
+    process.BadChargedCandidateFilter
 )
 
 ### Vanilla MET
 # this is the most basic MET one can find
 # even if we override with various types of MET later on, create this so we have a consistent calo MET
+# https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
+
 from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
+
 runMetCorAndUncFromMiniAOD(
     process,
     isData = options.isData,
@@ -169,6 +206,10 @@ metSequence = cms.Sequence(
 )
 
 ### PUPPI
+# TODO find PUPPI recipes, the following doesn't look right:
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/PUPPI
+# From PUPPI MET recipe in
+# https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
 
 # 80X does not contain the latest & greatest PuppiPhoton; need to rerun for all config
 from PhysicsTools.PatAlgos.slimming.puppiForMET_cff import makePuppiesFromMiniAOD
@@ -301,6 +342,7 @@ if egFix:
     process.fullPatMetSequencePuppi.insert(process.fullPatMetSequencePuppi.index(process.patMetModuleSequencePuppi) + 1, puppiMETEGCorrSequence)
 
 ### EGAMMA ID
+# https://twiki.cern.ch/twiki/bin/view/CMS/EgammaIDRecipesRun2 ???
 
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import setupAllVIDIdsInModule, setupVIDElectronSelection, switchOnVIDElectronIdProducer, DataFormat
 # Loads egmGsfElectronIDs
@@ -430,6 +472,7 @@ process.reco = cms.Path(
 
 if jetRecorrection:
     ### JET RE-CORRECTION
+    # ???
 
     from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJetCorrFactors, updatedPatJets
 
@@ -484,7 +527,8 @@ if muFix or egFix:
         met = 'slimmedMETsUncorrected'
     )
 else:
-    process.panda.fillers.pfMet.met = 'slimmedMets'
+    process.panda.fillers.pfMet.met = 'slimmedMETs'
+
 if muFix:
     process.panda.fillers.pfMet.met = 'slimmedMetsMuonFixed'
 if egFix:
@@ -496,6 +540,9 @@ if egFix:
     )
     process.panda.fillers.metFilters.dupECALClusters = cms.untracked.string('particleFlowEGammaGSFixed:dupECALClusters')
     process.panda.fillers.metFilters.unfixedECALHits = cms.untracked.string('ecalMultiAndGSGlobalRecHitEB:hitsNotReplaced')
+if not egRegression:
+    del process.panda.fillers.electrons.regressionElectrons
+    del process.panda.fillers.photons.regressionPhotons
 
 process.panda.outputFile = options.outputFile
 process.panda.printLevel = options.printLevel

--- a/Producer/cfg/mc.py
+++ b/Producer/cfg/mc.py
@@ -1,6 +1,6 @@
 from FWCore.ParameterSet.VarParsing import VarParsing
 
-options =VarParsing('analysis')
+options = VarParsing('analysis')
 options.register('config', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Single-switch config. Values: 03Feb2017, 23Sep2016, Spring16, Summer16')
 options.register('globaltag', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Global tag')
 options.register('connect', default = '', mult = VarParsing.multiplicity.singleton, mytype = VarParsing.varType.string, info = 'Globaltag connect')

--- a/Producer/plugins/PandaProducer.cc
+++ b/Producer/plugins/PandaProducer.cc
@@ -1,3 +1,4 @@
+#include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/Producer/python/utils/egmidconf.py
+++ b/Producer/python/utils/egmidconf.py
@@ -16,16 +16,19 @@ photonCHIsoEA = 'RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_co
 photonNHIsoEA = 'RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_cone03_pfNeutralHadrons_90percentBased.txt'
 photonPhIsoEA = 'RecoEgamma/PhotonIdentification/data/Spring16/effAreaPhotons_cone03_pfPhotons_90percentBased.txt'
 
+# https://twiki.cern.ch/twiki/bin/view/CMS/EGMSmearer#Energy_smearing_and_scale_correc
+# https://github.com/ECALELFS/ScalesSmearings/tree/Moriond17_23Jan_v2
+
 electronSmearingData = {
     "Prompt2015":"PandaProd/Producer/data/ScalesSmearings/74X_Prompt_2015",
     "76XReReco" :"PandaProd/Producer/data/ScalesSmearings/76X_16DecRereco_2015_Etunc",
     "80Xapproval" : "PandaProd/Producer/data/ScalesSmearings/80X_ichepV1_2016_ele",
-    "Moriond2017_JEC" : "PandaProd/Producer/data/ScalesSmearings/Winter_2016_reReco_v1_ele" #only to derive JEC correctionsb
+    "Moriond2017_JEC" : "PandaProd/Producer/data/ScalesSmearings/Winter_2016_reReco_v1_ele"     #only to derive JEC corrections
 }
 
 photonSmearingData = {
     "Prompt2015":"PandaProd/Producer/data/ScalesSmearings/74X_Prompt_2015",
     "76XReReco" :"PandaProd/Producer/data/ScalesSmearings/76X_16DecRereco_2015_Etunc",
     "80Xapproval" : "PandaProd/Producer/data/ScalesSmearings/80X_ichepV2_2016_pho",
-    "Moriond2017_JEC" : "PandaProd/Producer/data/ScalesSmearings/Winter_2016_reReco_v1_ele" #only to derive JEC correctionsb
+    "Moriond2017_JEC" : "PandaProd/Producer/data/ScalesSmearings/Winter_2016_reReco_v1_ele"     #only to derive JEC correctionsb
 }

--- a/Producer/src/ElectronsFiller.cc
+++ b/Producer/src/ElectronsFiller.cc
@@ -26,7 +26,7 @@ ElectronsFiller::ElectronsFiller(std::string const& _name, edm::ParameterSet con
 {
   getToken_(electronsToken_, _cfg, _coll, "electrons");
   getToken_(smearedElectronsToken_, _cfg, _coll, "smearedElectrons");
-  getToken_(regressionElectronsToken_, _cfg, _coll, "regressionElectrons");
+  getToken_(regressionElectronsToken_, _cfg, _coll, "regressionElectrons", false);
   getToken_(gsUnfixedElectronsToken_, _cfg, _coll, "gsUnfixedElectrons", false);
   getToken_(photonsToken_, _cfg, _coll, "photons", "photons");
   getToken_(pfCandidatesToken_, _cfg, _coll, "common", "pfCandidates");
@@ -82,7 +82,7 @@ ElectronsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::
 {
   auto& inElectrons(getProduct_(_inEvent, electronsToken_));
   auto& inSmearedElectrons(getProduct_(_inEvent, smearedElectronsToken_));
-  auto& inRegressionElectrons(getProduct_(_inEvent, regressionElectronsToken_));
+  auto* inRegressionElectrons(getProductSafe_(_inEvent, regressionElectronsToken_));
   auto* gsUnfixedElectrons(getProductSafe_(_inEvent, gsUnfixedElectronsToken_));
   auto& photons(getProduct_(_inEvent, photonsToken_));
   auto& pfCandidates(getProduct_(_inEvent, pfCandidatesToken_));
@@ -262,10 +262,12 @@ ElectronsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::
       }
     }
 
-    for (auto& reg : inRegressionElectrons) {
-      if (reg.superCluster() == scRef) {
-        outElectron.regPt = reg.pt();
-        break;
+    if (inRegressionElectrons) {
+      for (auto& reg : *inRegressionElectrons) {
+        if (reg.superCluster() == scRef) {
+          outElectron.regPt = reg.pt();
+          break;
+        }
       }
     }
 

--- a/Producer/src/PhotonsFiller.cc
+++ b/Producer/src/PhotonsFiller.cc
@@ -22,7 +22,7 @@ PhotonsFiller::PhotonsFiller(std::string const& _name, edm::ParameterSet const& 
 {
   getToken_(photonsToken_, _cfg, _coll, "photons");
   getToken_(smearedPhotonsToken_, _cfg, _coll, "smearedPhotons");
-  getToken_(regressionPhotonsToken_, _cfg, _coll, "regressionPhotons");
+  getToken_(regressionPhotonsToken_, _cfg, _coll, "regressionPhotons", false);
   getToken_(gsUnfixedPhotonsToken_, _cfg, _coll, "gsUnfixedPhotons", false);
   getToken_(pfCandidatesToken_, _cfg, _coll, "common", "pfCandidates");
   getToken_(ebHitsToken_, _cfg, _coll, "common", "ebHits");
@@ -81,7 +81,7 @@ PhotonsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::Ev
 {
   auto& inPhotons(getProduct_(_inEvent, photonsToken_));
   auto& inSmearedPhotons(getProduct_(_inEvent, smearedPhotonsToken_));
-  auto& inRegressionPhotons(getProduct_(_inEvent, regressionPhotonsToken_));
+  auto* inRegressionPhotons(getProductSafe_(_inEvent, regressionPhotonsToken_));
   auto* gsUnfixedPhotons(getProductSafe_(_inEvent, gsUnfixedPhotonsToken_));
   auto& pfCandidates(getProduct_(_inEvent, pfCandidatesToken_));
   auto& ebHits(getProduct_(_inEvent, ebHitsToken_));
@@ -314,10 +314,12 @@ PhotonsFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::Ev
       }
     }
 
-    for (auto& reg : inRegressionPhotons) {
-      if (reg.superCluster() == scRef) {
-        outPhoton.regPt = reg.pt();
-        break;
+    if (inRegressionPhotons) {
+      for (auto& reg : *inRegressionPhotons) {
+        if (reg.superCluster() == scRef) {
+          outPhoton.regPt = reg.pt();
+          break;
+        }
       }
     }
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ Package for production of PandA from CMSSW
 
 Installation
 
-cd $CMSSW_BASE/src
-eval `scram runtime -sh`
-./PandaProd/Producer/cfg/setuprel.sh
-scram b -j12
+    cd $CMSSW_BASE/src
+    eval `scram runtime -sh`
+    ./PandaProd/Producer/cfg/setuprel.sh
+    scram b -j12
 
 Run
 
-cmsRun PandaProd/Producer/cfg/prod.py [options]
+    cmsRun PandaProd/Producer/cfg/prod.py [options]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Installation
 
     cd $CMSSW_BASE/src
     eval `scram runtime -sh`
-    ./PandaProd/Producer/cfg/setuprel.sh
+
+    # Actually don't do this at the moment.
+    # None of the recipes even work in CMSSW_9_2_X
+    # ./PandaProd/Producer/cfg/setuprel.sh
+
     scram b -j12
 
 Run


### PR DESCRIPTION
Distributions were compared for the outputs of the following two commands:
 - In CMSSW_9_2_X branch featured in this PR:
````
cmsRun prod.py config=Prompt17 inputFiles=root://cms-xrd-global.cern.ch//store/data/Run2016B/MET/MINIAOD/03Feb2017_ver2-v2/100000/72A7C4AD-47EE-E611-949F-0CC47A4D75F2.root
````
 - In 004 setup under cmsprod user:
````
cmsRun ~cmsprod/Tools/Kraken/pandaf/004/data.py inputFiles=root://cms-xrd-global.cern.ch//store/data/Run2016B/MET/MINIAOD/03Feb2017_ver2-v2/100000/72A7C4AD-47EE-E611-949F-0CC47A4D75F2.root
````

Distribution plots are here: http://t3serv001.mit.edu/~dabercro/plotviewer/?share=True&expr=&width=4&dirs[]=170622_quick