### PR TITLE
Working around trigger object and ghost track problems seen in 006 production

### DIFF
--- a/Producer/cfg/data.py
+++ b/Producer/cfg/data.py
@@ -24,7 +24,7 @@ egmSmearingType = 'Moriond2017_JEC'
 
 if options.config == 'Prompt2017':
     options.isData = True
-    options.globaltag = '92X_dataRun2_Prompt_v4'
+    options.globaltag = '92X_dataRun2_Prompt_v6'
 
 elif options.config:
     raise RuntimeError('Unknown config ' + options.config)

--- a/Producer/cfg/prod.py
+++ b/Producer/cfg/prod.py
@@ -22,7 +22,7 @@ egmSmearingType = 'Moriond2017_JEC'
 
 if options.config == 'Prompt2017':
     options.isData = True
-    options.globaltag = '92X_dataRun2_Prompt_v4'
+    options.globaltag = '92X_dataRun2_Prompt_v6'
 
 elif options.config:
     raise RuntimeError('Unknown config ' + options.config)

--- a/Producer/cfg/prod.py
+++ b/Producer/cfg/prod.py
@@ -209,6 +209,7 @@ ca15PuppiSequence = makeFatJets(
 )
 
 from PandaProd.Producer.utils.setupBTag import initBTag, setupDoubleBTag
+# initBTag is already being called in makeFatJets() but we call it here again to eliminate implicit dependence between parts of config
 initBTag(process, '', 'packedPFCandidates', 'offlineSlimmedPrimaryVertices')
 ak8CHSDoubleBTagSequence = setupDoubleBTag(process, 'packedPatJetsAK8PFchs', 'AK8PFchs', '', 'ak8')
 ak8PuppiDoubleBTagSequence = setupDoubleBTag(process, 'packedPatJetsAK8PFPuppi', 'AK8PFPuppi', '', 'ak8')

--- a/Producer/interface/HLTFiller.h
+++ b/Producer/interface/HLTFiller.h
@@ -16,6 +16,7 @@ class HLTFiller : public FillerBase {
   void branchNames(panda::utils::BranchList& eventBranches, panda::utils::BranchList&) const override;
   void fill(panda::Event&, edm::Event const&, edm::EventSetup const&) override;
   void fillBeginRun(panda::Run&, edm::Run const&, edm::EventSetup const&) override;
+  void notifyNewProduct(edm::BranchDescription const&, edm::ConsumesCollector&) override;
 
  protected:
   typedef edm::View<pat::TriggerObjectStandAlone> TriggerObjectView;

--- a/Producer/python/panda_cfi.py
+++ b/Producer/python/panda_cfi.py
@@ -306,8 +306,7 @@ panda = cms.EDAnalyzer('PandaProducer',
         hlt = cms.untracked.PSet(
             enabled = cms.untracked.bool(True),
             filler = cms.untracked.string('HLT'),
-            triggerResults = cms.untracked.string('TriggerResults::HLT'),
-            triggerObjects = cms.untracked.string('slimmedPatTrigger')
+            triggerResults = cms.untracked.string('TriggerResults::HLT')
         ),
         weights = cms.untracked.PSet(
             enabled = cms.untracked.bool(True),

--- a/Producer/python/utils/setupBTag.py
+++ b/Producer/python/utils/setupBTag.py
@@ -98,7 +98,8 @@ def makeIpTagInfos(jetCollectionName, vsuffix, deltaR = 0.4):
         jets = jetCollectionName,
         candidates = vertexingConfig[vsuffix][0],
         primaryVertex = vertexingConfig[vsuffix][1],
-        maxDeltaR = deltaR
+        maxDeltaR = deltaR,
+        computeGhostTrack = False
     )
 
 def makeIvfTagInfos(ipTagInfosName, vsuffix, deltaR = 0.3):

--- a/Producer/src/HLTFiller.cc
+++ b/Producer/src/HLTFiller.cc
@@ -7,7 +7,9 @@ HLTFiller::HLTFiller(std::string const& _name, edm::ParameterSet const& _cfg, ed
   FillerBase(_name, _cfg)
 {
   getToken_(triggerResultsToken_, _cfg, _coll, "triggerResults");
-  getToken_(triggerObjectsToken_, _cfg, _coll, "triggerObjects");
+  // Trigger object collection name was different in 2017A PromptReco
+  // Using notifyNewProduct() to dynamically find the tag
+  triggerObjectsToken_.first = "triggerObjects";
 }
 
 HLTFiller::~HLTFiller()
@@ -138,6 +140,15 @@ HLTFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::EventS
   }
 
   _outEvent.triggerObjects.makeMap(*filters_);
+}
+
+void
+HLTFiller::notifyNewProduct(edm::BranchDescription const& _bdesc, edm::ConsumesCollector& _coll)
+{
+  if (_bdesc.unwrappedTypeID() == edm::TypeID(typeid(std::vector<pat::TriggerObjectStandAlone>))) {
+    edm::InputTag tag(_bdesc.moduleLabel(), _bdesc.productInstanceName(), _bdesc.processName());
+    triggerObjectsToken_.second = _coll.consumes<TriggerObjectView>(tag);
+  }
 }
 
 DEFINE_TREEFILLER(HLTFiller);


### PR DESCRIPTION
- New global tag: requires 9_2_6.
- Turned off ghost track computation in IPTagInfos because it was causing segfaults in some specific files. Looking at the CMSSW code, this option does nothing for us.
- HLTFilter now uses a dynamic tag for trigger objects to be compatible with 2017A and 2016B prompt recos.