### PR TITLE
HLT bug fix

### DIFF
--- a/Producer/src/HLTFiller.cc
+++ b/Producer/src/HLTFiller.cc
@@ -40,14 +40,13 @@ HLTFiller::fillBeginRun(panda::Run& _outRun, edm::Run const& _inRun, edm::EventS
 
   TString menu(hltConfig_.tableName());
 
-  // _outRun.hlt is not reset at each init() call
-  if (!configChanged) {
-    if (menu != *_outRun.hlt.menu)
-      throw edm::Exception(edm::errors::Configuration, "HLTFiller")
-        << "HLTConfigProvider claims nothing is changed, but the menu name did.";
-
-    return;
-  }
+  // _outRun.hlt is not reset at each init() call, but _outRun itself is reset.
+  // In particular _outRun.hltMenu is set to 0 at each beginRun(), which means
+  // we must load the current menu from menuMap + hltTree even when the configuration
+  // has not changed.
+  if (!configChanged && menu != *_outRun.hlt.menu)
+    throw edm::Exception(edm::errors::Configuration, "HLTFiller")
+      << "HLTConfigProvider claims nothing is changed, but the menu name did.";
 
   *_outRun.hlt.menu = menu;
   auto menuItr(menuMap_.find(menu));
@@ -57,6 +56,8 @@ HLTFiller::fillBeginRun(panda::Run& _outRun, edm::Run const& _inRun, edm::EventS
   filterIndices_.clear();
 
   if (menuItr != menuMap_.end()) {
+    // We have processed this menu before. Loading it from the tree.
+
     _outRun.hltMenu = menuItr->second;
     hltTree_->GetEntry(_outRun.hltMenu);
     
@@ -66,6 +67,8 @@ HLTFiller::fillBeginRun(panda::Run& _outRun, edm::Run const& _inRun, edm::EventS
 
     return;
   }
+
+  // First encounter with the menu. Increment the menuMap size.
 
   _outRun.hltMenu = menuMap_.size();
   menuMap_.emplace(menu, _outRun.hltMenu);


### PR DESCRIPTION
This was a bad bug. I think we should invalidate collision datasets in 008 and have production resubmit with this fix - but Kraken failed to load new tarballs last time, so maybe a 009 version is a surer solution.