### PR TITLE
Update Jenkinsfile to run on development branch in PandaTree.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,13 @@
 def in_files = ['E0A114B0-56F1-E711-8C5F-44A842B46A7E', '023E56A6-4FF3-E711-867C-68B59972C49E']
 
 def cmssw_version = 'CMSSW_9_4_4'
+def scram_arch = 'slc6_amd64_gcc630'
 def panda_tree_user = 'PandaPhysics'
-def panda_tree_branch = 'master'
+def panda_tree_branch = 'branch-010-devel'
 
 //// Hopefully you don't need to change much of what follows
 
-def do_src = 'set +x; export SCRAM_ARCH=slc6_amd64_gcc530; source /cvmfs/cms.cern.ch/cmsset_default.sh; set -x'
+def do_src = "set +x; export SCRAM_ARCH=${scram_arch}; source /cvmfs/cms.cern.ch/cmsset_default.sh; set -x"
 
 def prComment(message) {
   withCredentials([usernameColonPassword(credentialsId: 'mitsidekick', variable: 'USERPASS')]) {


### PR DESCRIPTION
This will get Jenkins through the compilation stage again. We'll probably want to change `panda_tree_branch` back to `master` after PandaTree is finalized for production.

I realize this isn't ideal, and Jenkins has a built-in way to support project dependencies which we should use someday. That will probably take me more time than I should spend right now to to figure out though.