### PR TITLE
Topic drop makemap

### DIFF
--- a/Producer/src/HLTFiller.cc
+++ b/Producer/src/HLTFiller.cc
@@ -141,8 +141,6 @@ HLTFiller::fill(panda::Event& _outEvent, edm::Event const& _inEvent, edm::EventS
     objMap.add(ptr, outObj);
     nameMap.add(ptr, filterNames_[iObj]);
   }
-
-  _outEvent.triggerObjects.makeMap(*filters_);
 }
 
 void


### PR DESCRIPTION
- `makeMap` has a different signature now. Just dropping the line because we would never use the HLTObjectStore map while filling the Panda trees.