### PR TITLE
setup for 2018 PromptReco

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 //// DEFINE THESE PLEASE ////
 
-def in_files = ['E0A114B0-56F1-E711-8C5F-44A842B46A7E', '023E56A6-4FF3-E711-867C-68B59972C49E']
+def in_files = ['7C75991C-535C-E811-B931-FA163E3A8726', '7E2944AD-145E-E811-90D7-FA163E11797A']
 
-def cmssw_version = 'CMSSW_9_4_6'
+def cmssw_version = 'CMSSW_10_1_4'
 def scram_arch = 'slc6_amd64_gcc630'
 def panda_tree_user = 'PandaPhysics'
-def panda_tree_branch = 'branch-010-devel'
+def panda_tree_branch = 'master'
 
 //// Hopefully you don't need to change much of what follows
 

--- a/Producer/cfg/data-2018Prompt.py
+++ b/Producer/cfg/data-2018Prompt.py
@@ -16,6 +16,8 @@ options._tagOrder.remove('numEvent%d')
 
 options.parseArguments()
 
+options.config = '2018Prompt'
+
 # Global tags
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions
 

--- a/Producer/cfg/data.py
+++ b/Producer/cfg/data.py
@@ -26,6 +26,9 @@ if options.config == '31Mar2018':
     options.isData = True
     options.globaltag = '94X_dataRun2_ReReco_EOY17_v6'
     options.redojec = True
+elif options.config == '2018Prompt':
+    options.isData = True
+    options.globaltag = '101X_dataRun2_Prompt_v10'
 elif options.config == 'Fall17':
     options.isData = False
     options.globaltag = '94X_mc2017_realistic_v14'

--- a/Producer/cfg/mc-Summer16.py
+++ b/Producer/cfg/mc-Summer16.py
@@ -16,6 +16,8 @@ options._tagOrder.remove('numEvent%d')
 
 options.parseArguments()
 
+options.config = 'Summer16'
+
 # Global tags
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions
 

--- a/Producer/cfg/mc.py
+++ b/Producer/cfg/mc.py
@@ -26,6 +26,9 @@ if options.config == '31Mar2018':
     options.isData = True
     options.globaltag = '94X_dataRun2_ReReco_EOY17_v6'
     options.redojec = True
+elif options.config == '2018Prompt':
+    options.isData = True
+    options.globaltag = '101X_dataRun2_Prompt_v10'
 elif options.config == 'Fall17':
     options.isData = False
     options.globaltag = '94X_mc2017_realistic_v14'

--- a/Producer/cfg/setuprel.sh
+++ b/Producer/cfg/setuprel.sh
@@ -13,6 +13,8 @@ $INSTALL lsoffi CMSSW_9_4_0_pre3_TnP RecoEgamma/ElectronIdentification RecoEgamm
 # MVA electron ID
 # RecoEgamma/ElectronIdentification overlaps with the line above but most of the files added above are not contained in this branch and thus will not be overwritten
 $INSTALL guitargeek ElectronID_MVA2017_940pre3 RecoEgamma/EgammaTools RecoEgamma/ElectronIdentification -x RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_tools.py
+# This is getting ridiculous (difference between 94X and 101X is purely technical)
+cp $CMSSW_RELEASE_BASE/src/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc $SRC/RecoEgamma/EgammaTools/src/EcalClusterLocal.cc
 
 # MVA weights for ID
 git clone -b CMSSW_9_4_0_pre3_TnP https://github.com/lsoffi/RecoEgamma-ElectronIdentification.git electronid
@@ -38,6 +40,12 @@ $INSTALL cms-met METRecipe94x PhysicsTools/PatAlgos PhysicsTools/PatUtils
 # Deep double B tagger from FNAL
 #$INSTALL jmduarte double-b-rebased-94x  RecoBTag/Combined RecoBTag/Configuration RecoBTag/DeepFlavour DataFormats/BTauReco PhysicsTools/PatAlgos
 $INSTALL DylanHsu double-b-rebased-94x  RecoBTag/Combined RecoBTag/Configuration RecoBTag/DeepFlavour DataFormats/BTauReco PhysicsTools/PatAlgos
+
+cp $CMSSW_RELEASE_BASE/src/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h $SRC/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+cp $CMSSW_RELEASE_BASE/src/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc $SRC/PhysicsTools/PatAlgos/plugins/PATElectronProducer.cc
+cp $CMSSW_RELEASE_BASE/src/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc $SRC/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+cp $CMSSW_RELEASE_BASE/src/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc $SRC/PhysicsTools/PatAlgos/plugins/PATElectronSlimmer.cc
+cp $CMSSW_RELEASE_BASE/src/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc $SRC/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
 
 # clone to a temp area and move the contents to avoid including .git
 TEMP=$(mktemp -d)


### PR DESCRIPTION
This a version that compiles on CMSSW_10_1_4 and runs on Run2018A PromptReco. There are changes to setuprel.sh but they have no effect on 010/9_4_6, so the branch can be merged to master and can be used for both setup changing the `config` parameter of prod.py.