### PR TITLE
Made PandaProducer multithread-friendly

### DIFF
--- a/Producer/cfg/data-2018Prompt.py
+++ b/Producer/cfg/data-2018Prompt.py
@@ -41,6 +41,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer', 'JetPtMismatchAtLowPt', 'JetPtMismatch', 'NullTransverseMomentum', 'MissingJetConstituent']:

--- a/Producer/cfg/data.py
+++ b/Producer/cfg/data.py
@@ -41,6 +41,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer', 'JetPtMismatchAtLowPt', 'JetPtMismatch', 'NullTransverseMomentum', 'MissingJetConstituent']:

--- a/Producer/cfg/gen.py
+++ b/Producer/cfg/gen.py
@@ -24,6 +24,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer']:

--- a/Producer/cfg/mc-Summer16.py
+++ b/Producer/cfg/mc-Summer16.py
@@ -45,6 +45,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer', 'JetPtMismatchAtLowPt', 'JetPtMismatch', 'NullTransverseMomentum', 'MissingJetConstituent']:

--- a/Producer/cfg/mc.py
+++ b/Producer/cfg/mc.py
@@ -41,6 +41,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(1),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer', 'JetPtMismatchAtLowPt', 'JetPtMismatch', 'NullTransverseMomentum', 'MissingJetConstituent']:

--- a/Producer/cfg/prod.py
+++ b/Producer/cfg/prod.py
@@ -43,6 +43,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('NTUPLES')
 
+process.options = cms.untracked.PSet(
+    numberOfThreads = cms.untracked.uint32(8),
+    numberOfStreams = cms.untracked.uint32(0)
+)
+
 process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
 for cat in ['PandaProducer', 'JetPtMismatchAtLowPt', 'JetPtMismatch', 'NullTransverseMomentum', 'MissingJetConstituent']:

--- a/Producer/cfg/prod.py
+++ b/Producer/cfg/prod.py
@@ -44,7 +44,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process('NTUPLES')
 
 process.options = cms.untracked.PSet(
-    numberOfThreads = cms.untracked.uint32(8),
+    numberOfThreads = cms.untracked.uint32(1),
     numberOfStreams = cms.untracked.uint32(0)
 )
 


### PR DESCRIPTION
Made PandaProducer into an `edm::one::EDAnalyzer`. In the normal production sequence, nothing will actually change because we'll be running jobs with a single thread - it is faster (in terms of events / second processed) to run 8 single-threaded jobs on a worker node than to run 1 eight-threaded job. Our jobs are not so memory-heavy, so there is no reason to make the production jobs multithreaded.

This change does matter for private production using e.g. gridpanda from subMIT. There we can grab 8-core condor slots and run generation-simulation-reconstruction multi-threaded. It is therefore beneficial to run the last panda step also on multiple cores, because otherwise we'll leave 7 cores of the condor slot idle.